### PR TITLE
delay rendering loading

### DIFF
--- a/src/core/loadingView.js
+++ b/src/core/loadingView.js
@@ -1,7 +1,21 @@
-import {h} from 'preact';
+import {h, Component} from 'preact';
 import Logo from '../icons/logo.js';
 import styles from './routeLoading.css';
 
-export default function LoadingView() {
-  return <div class={styles.routeLoading}><Logo width={60} height={60} /></div>;
+export default class LoadingView extends Component {
+  state = {render: false};
+  componentDidMount() {
+    const reasonableDelay = 200;
+    setTimeout(
+      () => {
+        this.setState({render: true});
+      },
+      reasonableDelay
+    );
+  }
+  render() {
+    return this.state.render
+      ? <div class={styles.routeLoading}><Logo width={60} height={60} /></div>
+      : null;
+  }
 }


### PR DESCRIPTION
This will help avoid the [Flash of Loading Content (FOLC)](https://twitter.com/ryanflorence/status/839863154481889282). This is effectively what [react-loadable](https://github.com/thejameskyle/react-loadable) does to solve the problem.